### PR TITLE
Fix getMaxZoom to use props.maxZoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1 Release
+
+- Fix getMaxZoom returning props.radius instead of props.maxZoom, fix misnamed call to getMax instead of getMaxZoom in redraw()
+
 # 0.2.0 Release
 
 - adds an `onStatsUpdate` prop which is called on redraw with a { min, max } object containing the min and max number of items found for a single coordinate

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -114,7 +114,7 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype.getMaxZoom = function getMaxZoom(props) {
-    return props.radius || 18;
+    return props.maxZoom || 18;
   };
 
   HeatmapLayer.prototype.getMinOpacity = function getMinOpacity(props) {

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -236,7 +236,7 @@ var HeatmapLayer = function (_MapLayer) {
 
     var maxIntensity = this.props.max === undefined ? 1 : this.getMax(this.props);
 
-    var maxZoom = this.props.maxZoom === undefined ? this.props.map.getMaxZoom() : this.getMax(this.props);
+    var maxZoom = this.props.maxZoom === undefined ? this.props.map.getMaxZoom() : this.getMaxZoom(this.props);
 
     var v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this.props.map.getZoom(), 12)));
 

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -110,7 +110,7 @@ export default class HeatmapLayer extends MapLayer {
   }
 
   getMaxZoom(props) {
-    return props.radius || 18;
+    return props.maxZoom || 18;
   }
 
   getMinOpacity(props) {

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -237,7 +237,7 @@ export default class HeatmapLayer extends MapLayer {
 
     const maxZoom = this.props.maxZoom === undefined
                         ? this.props.map.getMaxZoom()
-                        : this.getMax(this.props);
+                        : this.getMaxZoom(this.props);
 
     const v = 1 / Math.pow(
       2,


### PR DESCRIPTION
getMaxZoom looks like it was copied from getRadius, but was not changed to return maxZoom.

This corrects that issue, maxZoom is broken without this fix.