### PR TITLE
Support layers as in react-leaflet 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.3 Release
+- Missed Transpilation
+
 # 0.2.2 Release
 - Change `getHeatmapProps` signature to take a `props` argument to support passing `nextProps` from `componentWillReceiveProps` and `this.props` from `componentDidMount`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.2 Release
+- Change `getHeatmapProps` signature to take a `props` argument to support passing `nextProps` from `componentWillReceiveProps` and `this.props` from `componentDidMount`
+
 # 0.2.1 Release
 
 - Fix getMaxZoom returning props.radius instead of props.maxZoom, fix misnamed call to getMax instead of getMaxZoom in redraw()

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## Usage
 
+Use directly as a fixed layer:
+
 ```js
 import React from 'react';
 import { render } from 'react-dom';
@@ -39,6 +41,65 @@ class MapExample extends React.Component {
 
 render(<MapExample />, document.getElementById('app'));
 ```
+
+Or use it inside a layer control to toggle it:
+
+```js
+import React from 'react';
+import { render } from 'react-dom';
+import { Map, Marker, Popup, TileLayer } from 'react-leaflet';
+import HeatmapLayer from '../src/HeatmapLayer';
+import { addressPoints } from './realworld.10000.js';
+
+class MapExample extends React.Component {
+
+  render() {
+    return (
+      <div>
+      <Map center={position} zoom={13} style={{ height: '100%' }} >
+            <LayersControl>
+              <LayersControl.BaseLayer name="Base" checked>
+                <TileLayer
+                  url="http://{s}.tile.osm.org/{z}/{x}/{y}.png"
+                  attribution="&copy; <a href=http://osm.org/copyright>OpenStreetMap</a> contributors"
+                />
+              </LayersControl.BaseLayer>
+              <LayersControl.Overlay name="Heatmap" checked>
+                <FeatureGroup color="purple">
+                  <Marker position={[50.05, -0.09]} >
+                    <Popup>
+                      <span>A pretty CSS3 popup.<br /> Easily customizable. </span>
+                    </Popup>
+                  </Marker>
+                  <HeatmapLayer
+                    fitBoundsOnLoad
+                    fitBoundsOnUpdate
+                    points={addressPoints}
+                    longitudeExtractor={m => m[1]}
+                    latitudeExtractor={m => m[0]}
+                    intensityExtractor={m => parseFloat(m[2])}
+                  />
+                </FeatureGroup>
+              </LayersControl.Overlay>
+              <LayersControl.Overlay name="Marker">
+                <FeatureGroup color="purple">
+                  <Marker position={position} >
+                    <Popup>
+                      <span>A pretty CSS3 popup.<br /> Easily customizable. </span>
+                    </Popup>
+                  </Marker>
+                </FeatureGroup>
+              </LayersControl.Overlay>
+            </LayersControl>
+          </Map>
+      </div>
+    );
+  }
+}
+
+render(<MapExample />, document.getElementById('app'));
+```
+
 
 ## API
 

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -89,6 +89,10 @@ var HeatmapLayer = function (_MapLayer) {
     return _possibleConstructorReturn(this, _MapLayer.apply(this, arguments));
   }
 
+  HeatmapLayer.prototype.createLeafletElement = function createLeafletElement() {
+    return null;
+  };
+
   HeatmapLayer.prototype.componentDidMount = function componentDidMount() {
     var _style;
 

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -2,8 +2,6 @@
 
 exports.__esModule = true;
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -92,9 +90,44 @@ var HeatmapLayer = function (_MapLayer) {
   }
 
   HeatmapLayer.prototype.componentDidMount = function componentDidMount() {
-    this.leafletElement = _reactDom2.default.findDOMNode(this.refs.container);
-    this.props.map.getPanes().overlayPane.appendChild(this.leafletElement);
-    this._heatmap = (0, _simpleheat2.default)(this.leafletElement);
+    var _style;
+
+    var canAnimate = this.context.map.options.zoomAnimation && _leaflet2.default.Browser.any3d;
+    var zoomClass = 'leaflet-zoom-' + (canAnimate ? 'animated' : 'hide');
+    var mapSize = this.context.map.getSize();
+    var transformProp = _leaflet2.default.DomUtil.testProp(['transformOrigin', 'WebkitTransformOrigin', 'msTransformOrigin']);
+
+    var canvasProps = {
+      className: 'leaflet-heatmap-layer leaflet-layer ' + zoomClass,
+      style: (_style = {}, _style[transformProp] = '50% 50%', _style),
+      width: mapSize.x,
+      height: mapSize.y
+    };
+
+    this._el = _leaflet2.default.DomUtil.create('canvas', zoomClass);
+    this._el.style[transformProp] = '50% 50%';
+    this._el.width = mapSize.x;
+    this._el.height = mapSize.y;
+
+    var el = this._el;
+
+    var element = _leaflet2.default.Layer.extend({
+      onAdd: function onAdd(map) {
+        map.getPanes().overlayPane.appendChild(el);
+      },
+      addTo: function addTo(map) {
+        map.addLayer(this);
+        return this;
+      },
+      onRemove: function onRemove(map) {
+        map.getPanes().overlayPane.removeChild(el);
+      }
+    });
+
+    this.leafletElement = new element();
+    _MapLayer.prototype.componentDidMount.call(this);
+    this._heatmap = (0, _simpleheat2.default)(this._el);
+    this.reset();
 
     if (this.props.fitBoundsOnLoad) {
       this.fitBounds();
@@ -102,7 +135,6 @@ var HeatmapLayer = function (_MapLayer) {
 
     this.attachEvents();
     this.updateHeatmapProps(this.getHeatmapProps(this.props));
-    this.reset();
   };
 
   HeatmapLayer.prototype.getMax = function getMax(props) {
@@ -155,7 +187,7 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype.componentWillUnmount = function componentWillUnmount() {
-    this.props.map.getPanes().overlayPane.removeChild(this.leafletElement);
+    this.context.map.getPanes().overlayPane.removeChild(this._el);
   };
 
   HeatmapLayer.prototype.fitBounds = function fitBounds() {
@@ -169,11 +201,11 @@ var HeatmapLayer = function (_MapLayer) {
       return;
     }
 
-    this.props.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)));
+    this.context.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)));
   };
 
   HeatmapLayer.prototype.componentDidUpdate = function componentDidUpdate() {
-    this.props.map.invalidateSize();
+    this.context.map.invalidateSize();
     if (this.props.fitBoundsOnUpdate) {
       this.fitBounds();
     }
@@ -187,7 +219,7 @@ var HeatmapLayer = function (_MapLayer) {
   HeatmapLayer.prototype.attachEvents = function attachEvents() {
     var _this2 = this;
 
-    var map = this.props.map;
+    var map = this.context.map;
     map.on('viewreset', function () {
       return _this2.reset();
     });
@@ -200,30 +232,30 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype._animateZoom = function _animateZoom(e) {
-    var scale = this.props.map.getZoomScale(e.zoom);
-    var offset = this.props.map._getCenterOffset(e.center)._multiplyBy(-scale).subtract(this.props.map._getMapPanePos());
+    var scale = this.context.map.getZoomScale(e.zoom);
+    var offset = this.context.map._getCenterOffset(e.center)._multiplyBy(-scale).subtract(this.context.map._getMapPanePos());
 
     if (_leaflet2.default.DomUtil.setTransform) {
-      _leaflet2.default.DomUtil.setTransform(this.refs.container, offset, scale);
+      _leaflet2.default.DomUtil.setTransform(this._el, offset, scale);
     } else {
-      this.refs.container.style[_leaflet2.default.DomUtil.TRANSFORM] = _leaflet2.default.DomUtil.getTranslateString(offset) + ' scale(' + scale + ')';
+      this._el.style[_leaflet2.default.DomUtil.TRANSFORM] = _leaflet2.default.DomUtil.getTranslateString(offset) + ' scale(' + scale + ')';
     }
   };
 
   HeatmapLayer.prototype.reset = function reset() {
-    var topLeft = this.props.map.containerPointToLayerPoint([0, 0]);
-    _leaflet2.default.DomUtil.setPosition(this.refs.container, topLeft);
+    var topLeft = this.context.map.containerPointToLayerPoint([0, 0]);
+    _leaflet2.default.DomUtil.setPosition(this._el, topLeft);
 
-    var size = this.props.map.getSize();
+    var size = this.context.map.getSize();
 
     if (this._heatmap._width !== size.x) {
-      this.refs.container.width = this._heatmap._width = size.x;
+      this._el.width = this._heatmap._width = size.x;
     }
     if (this._heatmap._height !== size.y) {
-      this.refs.container.height = this._heatmap._height = size.y;
+      this._el.height = this._heatmap._height = size.y;
     }
 
-    if (this._heatmap && !this._frame && !this.props.map._animating) {
+    if (this._heatmap && !this._frame && !this.context.map._animating) {
       this._frame = _leaflet2.default.Util.requestAnimFrame(this.redraw, this);
     }
 
@@ -232,17 +264,17 @@ var HeatmapLayer = function (_MapLayer) {
 
   HeatmapLayer.prototype.redraw = function redraw() {
     var r = this._heatmap._r;
-    var size = this.props.map.getSize();
+    var size = this.context.map.getSize();
 
     var maxIntensity = this.props.max === undefined ? 1 : this.getMax(this.props);
 
-    var maxZoom = this.props.maxZoom === undefined ? this.props.map.getMaxZoom() : this.getMaxZoom(this.props);
+    var maxZoom = this.props.maxZoom === undefined ? this.context.map.getMaxZoom() : this.getMaxZoom(this.props);
 
-    var v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this.props.map.getZoom(), 12)));
+    var v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this.context.map.getZoom(), 12)));
 
     var cellSize = r / 2;
     var grid = [];
-    var panePos = this.props.map._getMapPanePos();
+    var panePos = this.context.map._getMapPanePos();
     var offsetX = panePos.x % cellSize;
     var offsetY = panePos.y % cellSize;
     var getLat = this.props.latitudeExtractor;
@@ -310,7 +342,7 @@ var HeatmapLayer = function (_MapLayer) {
     var getDataForHeatmap = function getDataForHeatmap(points, leafletMap) {
       return roundResults(accumulateInGrid(points, leafletMap, getBounds(leafletMap)));
     };
-    var data = getDataForHeatmap(this.props.points, this.props.map);
+    var data = getDataForHeatmap(this.props.points, this.context.map);
 
     this._heatmap.clear();
     this._heatmap.data(data).draw(this.getMinOpacity(this.props));
@@ -329,21 +361,7 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype.render = function render() {
-    var _style;
-
-    var mapSize = this.props.map.getSize();
-    var transformProp = _leaflet2.default.DomUtil.testProp(['transformOrigin', 'WebkitTransformOrigin', 'msTransformOrigin']);
-    var canAnimate = this.props.map.options.zoomAnimation && _leaflet2.default.Browser.any3d;
-    var zoomClass = 'leaflet-zoom-' + (canAnimate ? 'animated' : 'hide');
-
-    var canvasProps = {
-      className: 'leaflet-heatmap-layer leaflet-layer ' + zoomClass,
-      style: (_style = {}, _style[transformProp] = '50% 50%', _style),
-      width: mapSize.x,
-      height: mapSize.y
-    };
-
-    return _react2.default.createElement('canvas', _extends({ ref: 'container' }, canvasProps));
+    return null;
   };
 
   return HeatmapLayer;

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -101,7 +101,7 @@ var HeatmapLayer = function (_MapLayer) {
     }
 
     this.attachEvents();
-    this.updateHeatmapProps(this.getHeatmapProps());
+    this.updateHeatmapProps(this.getHeatmapProps(this.props));
     this.reset();
   };
 
@@ -125,14 +125,14 @@ var HeatmapLayer = function (_MapLayer) {
     return props.blur || 15;
   };
 
-  HeatmapLayer.prototype.getHeatmapProps = function getHeatmapProps() {
+  HeatmapLayer.prototype.getHeatmapProps = function getHeatmapProps(props) {
     return {
-      minOpacity: this.getMinOpacity(this.props),
-      maxZoom: this.getMaxZoom(this.props),
-      radius: this.getRadius(this.props),
-      blur: this.getBlur(this.props),
-      max: this.getMax(this.props),
-      gradient: this.props.gradient
+      minOpacity: this.getMinOpacity(props),
+      maxZoom: this.getMaxZoom(props),
+      radius: this.getRadius(props),
+      blur: this.getBlur(props),
+      max: this.getMax(props),
+      gradient: props.gradient
     };
   };
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "author": "Jeremiah Hall <npm@jeremiahrhall.com>",
   "license": "MIT",
   "peerDependencies": {
-    "leaflet": ">=1.0.0",
-    "react-leaflet": ">=1.0.0",
-    "react": ">=15.4.1",
-    "react-dom": ">=15.4.1"
+    "leaflet": "^1.0.0",
+    "react-leaflet": "^1.0.0",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -51,11 +51,11 @@
     "eslint-plugin-arrow-function": "^2.0.0",
     "eslint-plugin-react": "^4.2.3",
     "jest-cli": "^0.9.2",
-    "leaflet": "^0.7.7",
-    "react": "^0.14.7",
+    "leaflet": "^1.0.0",
+    "react": "^15.4.1",
     "react-addons-test-utils": "^0.14.7",
-    "react-dom": "^0.14.7",
-    "react-leaflet": "^0.10.2",
+    "react-dom": "^15.4.1",
+    "react-leaflet": "^1.0.0",
     "react-transform-hmr": "^1.0.4",
     "webpack-dev-server": "^1.14.1",
     "webpack": "^1.12.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "0.2.3",
+  "version": "1.0.0",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "author": "Jeremiah Hall <npm@jeremiahrhall.com>",
   "license": "MIT",
   "peerDependencies": {
-    "leaflet": "^0.7.7",
-    "react-leaflet": "^0.10.2",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "leaflet": "^1.0.2",
+    "react-leaflet": "^1.0.0",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -87,6 +87,10 @@ export default class HeatmapLayer extends MapLayer {
     gradient: React.PropTypes.object
   };
 
+  createLeafletElement() {
+    return null;
+  }
+
   componentDidMount(): void {
 
     const canAnimate = this.context.map.options.zoomAnimation && L.Browser.any3d;

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -97,7 +97,7 @@ export default class HeatmapLayer extends MapLayer {
     }
 
     this.attachEvents();
-    this.updateHeatmapProps(this.getHeatmapProps());
+    this.updateHeatmapProps(this.getHeatmapProps(this.props));
     this.reset();
   }
 
@@ -121,14 +121,14 @@ export default class HeatmapLayer extends MapLayer {
     return props.blur || 15;
   }
 
-  getHeatmapProps() {
+  getHeatmapProps(props) {
     return {
-      minOpacity: this.getMinOpacity(this.props),
-      maxZoom: this.getMaxZoom(this.props),
-      radius: this.getRadius(this.props),
-      blur: this.getBlur(this.props),
-      max: this.getMax(this.props),
-      gradient: this.props.gradient
+      minOpacity: this.getMinOpacity(props),
+      maxZoom: this.getMaxZoom(props),
+      radius: this.getRadius(props),
+      blur: this.getBlur(props),
+      max: this.getMax(props),
+      gradient: props.gradient
     };
   }
 

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -66,7 +66,7 @@ function isValid(num: number): boolean {
 }
 
 function safeRemoveLayer (map, el) {
-  const {overlayPane} = map.getPanes()
+  const {overlayPane} = map.getPanes();
   if (overlayPane.contains(el)) {
     overlayPane.removeChild(el);
   }
@@ -99,7 +99,6 @@ export default class HeatmapLayer extends MapLayer {
   }
 
   componentDidMount(): void {
-
     const canAnimate = this.context.map.options.zoomAnimation && L.Browser.any3d;
     const zoomClass = `leaflet-zoom-${canAnimate ? 'animated' : 'hide'}`;
     const mapSize = this.context.map.getSize();
@@ -132,7 +131,7 @@ export default class HeatmapLayer extends MapLayer {
         return this;
       },
       onRemove: function(map) {
-        safeRemoveLayer(map, el)
+        safeRemoveLayer(map, el);
       }
     });
 


### PR DESCRIPTION
This pull request fixes #3 that @ruta-goomba addressed. Now, the heatmap can live inside nested controls as well as outside. It will respect toggling layers on and off.