### PR TITLE
Fix small unmount bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.1 Release
+- Fix bug in componentWillUnmount->safeRemoveLayer where getPanes doesn't return anything so .contains is called on undefined. 
+
 # 1.0.0 Release
 - Leaflet 1.0.0 support
 - React-Leaflet 1.0.0 support

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -68,7 +68,7 @@ function safeRemoveLayer(leafletMap, el) {
   var _leafletMap$getPanes = leafletMap.getPanes(),
       overlayPane = _leafletMap$getPanes.overlayPane;
 
-  if (overlayPane.contains(el)) {
+  if (overlayPane && overlayPane.contains(el)) {
     overlayPane.removeChild(el);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -64,7 +64,7 @@ function isInvalidLatLngArray(arr: Array<number>): boolean {
 
 function safeRemoveLayer(leafletMap: Map, el): void {
   const { overlayPane } = leafletMap.getPanes();
-  if (overlayPane.contains(el)) {
+  if (overlayPane && overlayPane.contains(el)) {
     overlayPane.removeChild(el);
   }
 }


### PR DESCRIPTION
I was getting `Cannot read property 'contains' of undefined` thrown (using Next.js) in componentWillUnmount. I tested this with my local project and it fixed the bug.