### PR TITLE
chore(deps): allow new versions of react and react-dom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.4 Release
+- Allow the latest versions of `react` and `react-dom` (i.e. 16 and up).
+
 # 1.0.3 Release
 - Fixed warning "Accessing PropTypes via the main React package is deprecated"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "peerDependencies": {
     "leaflet": "^1.0.0",
     "react-leaflet": "^1.0.0",
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "react": "^15.4.1 || ^16.0.0",
+    "react-dom": "^15.4.1 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   "peerDependencies": {
     "leaflet": "^1.0.0",
     "react-leaflet": "^1.0.0",
-    "react": "^15.4.1 || ^16.0.0",
-    "react-dom": "^15.4.1 || ^16.0.0"
+    "react": "^15.4.1 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -53,9 +52,9 @@
     "eslint-plugin-react": "^4.2.3",
     "leaflet": "^1.0.0",
     "prop-types": "^15.5.10",
-    "react": "^15.4.1",
+    "react": "^16.0.0",
     "react-addons-test-utils": "^0.14.7",
-    "react-dom": "^15.4.1",
+    "react-dom": "^16.0.0",
     "react-leaflet": "^1.0.0",
     "react-transform-hmr": "^1.0.4",
     "webpack": "^1.12.14",


### PR DESCRIPTION
Similar to #8, this allows newer versions of react and react-dom in a slightly more confined way (and shouldn't require a major bump).

@jeremiahrhall #8 is pretty outdated at this point. I'd recommend merging this, which I don't think would require a major bump and closing out #8.

BTW I'm also not sure if you need the `react-dom` peer dep as it's only used in the example but no where within the actual codebase. Most other `react` packages I've seen don't specify both anymore unless they explicitly use `react-dom`. Happy to remove this as well if you're comfortable with it.