### PR TITLE
set size on Map to prevent Failed to execute getImageData error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.4 Release
+- Documentation: Set height and width on <Map/> component to prevent getImageData error
+
 # 1.0.3 Release
 - Fixed warning "Accessing PropTypes via the main React package is deprecated"
 
@@ -5,7 +8,7 @@
 - Fix bug where radius, blur, and max were not being used when passed in as props.
 
 # 1.0.1 Release
-- Fix bug in componentWillUnmount->safeRemoveLayer where getPanes doesn't return anything so .contains is called on undefined. 
+- Fix bug in componentWillUnmount->safeRemoveLayer where getPanes doesn't return anything so .contains is called on undefined.
 
 # 1.0.0 Release
 - Leaflet 1.0.0 support

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ class MapExample extends React.Component {
   render() {
     return (
       <div>
-        <Map center={[0,0]} zoom={13}>
+        <Map center={[0,0]} zoom={13} style={{width: 500, height: 500}}>
           <HeatmapLayer
             fitBoundsOnLoad
             fitBoundsOnUpdate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {


### PR DESCRIPTION
There is a PR in simpleheat.js that this library depends on that hasn't been accepted yet: https://github.com/mourner/simpleheat/pull/34/files

There is another issue filed in this library that suggests a patch to the simpleheat.js that's pulled down with this library. That approach is fragile and can break in the future. https://github.com/OpenGov/react-leaflet-heatmap-layer/issues/14

Adding height and width on the <Map /> component fixes this problem so I'm including it in the documentation. 