### PR TITLE
Documentation on adding leaflet.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# 1.0.3 Release
-- Fixed warning "Accessing PropTypes via the main React package is deprecated"
+# 1.0.5 Release
+- Documentation on including leaflet.css
 
 # 1.0.2 Release
 - Fix bug where radius, blur, and max were not being used when passed in as props.
 
 # 1.0.1 Release
-- Fix bug in componentWillUnmount->safeRemoveLayer where getPanes doesn't return anything so .contains is called on undefined. 
+- Fix bug in componentWillUnmount->safeRemoveLayer where getPanes doesn't return anything so .contains is called on undefined.
 
 # 1.0.0 Release
 - Leaflet 1.0.0 support

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ import { render } from 'react-dom';
 import { Map, Marker, Popup, TileLayer } from 'react-leaflet';
 import HeatmapLayer from '../src/HeatmapLayer';
 import { addressPoints } from './realworld.10000.js';
+import 'leaflet/dist/leaflet.css' // leaflet.css is usually imported at the top-level index.js. Only needs to be done once
 
 class MapExample extends React.Component {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {


### PR DESCRIPTION
This is a common mistake. I've forgot it every time I use leaflet for the first time in a while. Here's some  examples: 
https://github.com/PaulLeCam/react-leaflet/issues/75
https://github.com/PaulLeCam/react-leaflet/issues/233

This reminds them to import leaflet.css.

Following the contributor guidelines, I added this to the changelog and bumped the package.json version. My previous PR (https://github.com/OpenGov/react-leaflet-heatmap-layer/pulls) should be accepted before this one so the numbering is correct.

I'm happy to change either of these PRs if needed. 