### PR TITLE
Support for react-leaflet v2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.0 Release
+- React-leaflet v2.x support. For react-leaflet v1.x please use react-leaflet-heatmep-layer v1.x.
+
 # 1.0.4 Release
 - Allow the latest versions of `react` and `react-dom` (i.e. 16 and up).
 

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -2,6 +2,8 @@
 
 exports.__esModule = true;
 
+var _class, _temp;
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -81,7 +83,7 @@ function shouldIgnoreLocation(loc) {
   return isInvalid(loc.lng) || isInvalid(loc.lat);
 }
 
-var HeatmapLayer = function (_MapLayer) {
+exports.default = (0, _reactLeaflet.withLeaflet)((_temp = _class = function (_MapLayer) {
   _inherits(HeatmapLayer, _MapLayer);
 
   function HeatmapLayer() {
@@ -97,9 +99,9 @@ var HeatmapLayer = function (_MapLayer) {
   HeatmapLayer.prototype.componentDidMount = function componentDidMount() {
     var _this2 = this;
 
-    var canAnimate = this.context.map.options.zoomAnimation && _leaflet2.default.Browser.any3d;
+    var canAnimate = this.props.leaflet.map.options.zoomAnimation && _leaflet2.default.Browser.any3d;
     var zoomClass = 'leaflet-zoom-' + (canAnimate ? 'animated' : 'hide');
-    var mapSize = this.context.map.getSize();
+    var mapSize = this.props.leaflet.map.getSize();
     var transformProp = _leaflet2.default.DomUtil.testProp(['transformOrigin', 'WebkitTransformOrigin', 'msTransformOrigin']);
 
     this._el = _leaflet2.default.DomUtil.create('canvas', zoomClass);
@@ -228,7 +230,7 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype.componentWillUnmount = function componentWillUnmount() {
-    safeRemoveLayer(this.context.map, this._el);
+    safeRemoveLayer(this.props.leaflet.map, this._el);
   };
 
   HeatmapLayer.prototype.fitBounds = function fitBounds() {
@@ -242,11 +244,11 @@ var HeatmapLayer = function (_MapLayer) {
       return;
     }
 
-    this.context.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)));
+    this.props.leaflet.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)));
   };
 
   HeatmapLayer.prototype.componentDidUpdate = function componentDidUpdate() {
-    this.context.map.invalidateSize();
+    this.props.leaflet.map.invalidateSize();
     if (this.props.fitBoundsOnUpdate) {
       this.fitBounds();
     }
@@ -260,7 +262,7 @@ var HeatmapLayer = function (_MapLayer) {
   HeatmapLayer.prototype.attachEvents = function attachEvents() {
     var _this3 = this;
 
-    var leafletMap = this.context.map;
+    var leafletMap = this.props.leaflet.map;
     leafletMap.on('viewreset', function () {
       return _this3.reset();
     });
@@ -273,8 +275,8 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype._animateZoom = function _animateZoom(e) {
-    var scale = this.context.map.getZoomScale(e.zoom);
-    var offset = this.context.map._getCenterOffset(e.center)._multiplyBy(-scale).subtract(this.context.map._getMapPanePos());
+    var scale = this.props.leaflet.map.getZoomScale(e.zoom);
+    var offset = this.props.leaflet.map._getCenterOffset(e.center)._multiplyBy(-scale).subtract(this.props.leaflet.map._getMapPanePos());
 
     if (_leaflet2.default.DomUtil.setTransform) {
       _leaflet2.default.DomUtil.setTransform(this._el, offset, scale);
@@ -284,10 +286,10 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype.reset = function reset() {
-    var topLeft = this.context.map.containerPointToLayerPoint([0, 0]);
+    var topLeft = this.props.leaflet.map.containerPointToLayerPoint([0, 0]);
     _leaflet2.default.DomUtil.setPosition(this._el, topLeft);
 
-    var size = this.context.map.getSize();
+    var size = this.props.leaflet.map.getSize();
 
     if (this._heatmap._width !== size.x) {
       this._el.width = this._heatmap._width = size.x;
@@ -296,7 +298,7 @@ var HeatmapLayer = function (_MapLayer) {
       this._el.height = this._heatmap._height = size.y;
     }
 
-    if (this._heatmap && !this._frame && !this.context.map._animating) {
+    if (this._heatmap && !this._frame && !this.props.leaflet.map._animating) {
       this._frame = _leaflet2.default.Util.requestAnimFrame(this.redraw, this);
     }
 
@@ -305,16 +307,16 @@ var HeatmapLayer = function (_MapLayer) {
 
   HeatmapLayer.prototype.redraw = function redraw() {
     var r = this._heatmap._r;
-    var size = this.context.map.getSize();
+    var size = this.props.leaflet.map.getSize();
 
     var maxIntensity = this.props.max === undefined ? 1 : this.getMax(this.props);
 
-    var maxZoom = this.props.maxZoom === undefined ? this.context.map.getMaxZoom() : this.getMaxZoom(this.props);
+    var maxZoom = this.props.maxZoom === undefined ? this.props.leaflet.map.getMaxZoom() : this.getMaxZoom(this.props);
 
-    var v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this.context.map.getZoom(), 12)));
+    var v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this.props.leaflet.map.getZoom(), 12)));
 
     var cellSize = r / 2;
-    var panePos = this.context.map._getMapPanePos();
+    var panePos = this.props.leaflet.map._getMapPanePos();
     var offsetX = panePos.x % cellSize;
     var offsetY = panePos.y % cellSize;
     var getLat = this.props.latitudeExtractor;
@@ -383,7 +385,7 @@ var HeatmapLayer = function (_MapLayer) {
       return roundResults(accumulateInGrid(points, leafletMap, getBounds(leafletMap)));
     };
 
-    var data = getDataForHeatmap(this.props.points, this.context.map);
+    var data = getDataForHeatmap(this.props.points, this.props.leaflet.map);
 
     this._heatmap.clear();
     this._heatmap.data(data).draw(this.getMinOpacity(this.props));
@@ -404,9 +406,7 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   return HeatmapLayer;
-}(_reactLeaflet.MapLayer);
-
-HeatmapLayer.propTypes = {
+}(_reactLeaflet.MapLayer), _class.propTypes = {
   points: _propTypes2.default.array.isRequired,
   longitudeExtractor: _propTypes2.default.func.isRequired,
   latitudeExtractor: _propTypes2.default.func.isRequired,
@@ -421,5 +421,4 @@ HeatmapLayer.propTypes = {
   minOpacity: _propTypes2.default.number,
   blur: _propTypes2.default.number,
   gradient: _propTypes2.default.object
-};
-exports.default = HeatmapLayer;
+}, _temp));

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -313,7 +313,7 @@ exports.default = (0, _reactLeaflet.withLeaflet)((_temp = _class = function (_Ma
 
     var maxZoom = this.props.maxZoom === undefined ? this.props.leaflet.map.getMaxZoom() : this.getMaxZoom(this.props);
 
-    var v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this.props.leaflet.map.getZoom(), 12)));
+    var v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this.props.leaflet.map.getZoom(), 12)) / 2);
 
     var cellSize = r / 2;
     var panePos = this.props.leaflet.map._getMapPanePos();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {
@@ -30,7 +30,7 @@
   "license": "MIT",
   "peerDependencies": {
     "leaflet": "^1.0.0",
-    "react-leaflet": "^1.0.0",
+    "react-leaflet": "^2.0.0",
     "react": "^15.4.1 || ^16.0.0"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
     "react": "^16.0.0",
     "react-addons-test-utils": "^0.14.7",
     "react-dom": "^16.0.0",
-    "react-leaflet": "^1.0.0",
+    "react-leaflet": "^2.0.0",
     "react-transform-hmr": "^1.0.4",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -307,7 +307,7 @@ export default withLeaflet(class HeatmapLayer extends MapLayer {
 
     const v = 1 / Math.pow(
       2,
-      Math.max(0, Math.min(maxZoom - this.props.leaflet.map.getZoom(), 12))
+      Math.max(0, Math.min(maxZoom - this.props.leaflet.map.getZoom(), 12)) / 2
     );
 
     const cellSize = r / 2;


### PR DESCRIPTION
Support for react-leaflet v2.0.
This PR breaks support of react-leaflet v1.0.
closes #33 