### PR TITLE
Prevent unhandled errors when the component redraws after unmounting

### DIFF
--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -306,6 +306,12 @@ exports.default = (0, _reactLeaflet.withLeaflet)((_temp = _class = function (_Ma
   };
 
   HeatmapLayer.prototype.redraw = function redraw() {
+    // It's possible that the map has unmounted while we've waited for an animation frame, so we
+    // need to check that it still exists before proceeding with the redraw.
+    if (!this.props.leaflet.map._mapPane) {
+      return;
+    }
+
     var r = this._heatmap._r;
     var size = this.props.leaflet.map.getSize();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -294,6 +294,12 @@ export default withLeaflet(class HeatmapLayer extends MapLayer {
   }
 
   redraw(): void {
+    // It's possible that the map has unmounted while we've waited for an animation frame, so we
+    // need to check that it still exists before proceeding with the redraw.
+    if (!this.props.leaflet.map._mapPane) {
+      return;
+    }
+
     const r = this._heatmap._r;
     const size = this.props.leaflet.map.getSize();
 


### PR DESCRIPTION
When the map component unmounts, it is possible for the `redraw()` method to be called when there is no longer a map element. For example:

![image](https://user-images.githubusercontent.com/8236564/78459577-03d2d500-7688-11ea-911e-c7186e81939e.png)

This PR is a trivial change that checks for `map._mapPane` existing before calling `map._getMapPanePos()` which triggers the unhandled exception.

Both the `src/` and `lib/` versions have been updated, the patch version has been bumped, linting passes except for in the `example/` directory where it was already failing, the code is tested and working, and I certify that the terms set out under "Developer's Certificate of Origin 1.1" are met by this contribution.