### PR TITLE
Fix maxZoom parameter not being used when calling the leaflet map.fit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1 Release
+- Fix `maxZoom` parameter not being used when calling the leaflet `map.fitBounds` function.
+
 # 2.0.0 Release
 - React-leaflet v2.x support. For react-leaflet v1.x please use react-leaflet-heatmep-layer v1.x.
 

--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -244,7 +244,8 @@ exports.default = (0, _reactLeaflet.withLeaflet)((_temp = _class = function (_Ma
       return;
     }
 
-    this.props.leaflet.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)));
+    var maxZoom = this.props.maxZoom === undefined ? this.props.leaflet.map.getMaxZoom() : this.getMaxZoom(this.props);
+    this.props.leaflet.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)), { maxZoom: maxZoom });
   };
 
   HeatmapLayer.prototype.componentDidUpdate = function componentDidUpdate() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-heatmap-layer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A custom layer for heatmaps in react-leaflet",
   "main": "lib/HeatmapLayer.js",
   "scripts": {

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -233,7 +233,11 @@ export default withLeaflet(class HeatmapLayer extends MapLayer {
       return;
     }
 
-    this.props.leaflet.map.fitBounds(L.latLngBounds(L.latLng(sw), L.latLng(ne)));
+
+    const maxZoom = this.props.maxZoom === undefined
+                        ? this.props.leaflet.map.getMaxZoom()
+                        : this.getMaxZoom(this.props);
+    this.props.leaflet.map.fitBounds(L.latLngBounds(L.latLng(sw), L.latLng(ne)), { maxZoom });
   }
 
   componentDidUpdate(): void {


### PR DESCRIPTION
…Bounds function.

Basically, when the bounds were fit, the only max zoom being taken into account were the global map's `maxZoom`. It's quite useful to allow the user to zoom in more if they want but when automatically updating the bounds it's less useful to zoom in super close.

For example:
- Map maxZoom: 18
- Heatmap maxZoom: 13